### PR TITLE
Feat/relatorios

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,34 @@
       		<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
       		<version>2.8.10</version>
    		</dependency>
-		   <dependency>
-      <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
-      <version>2.8.10</version>
-   </dependency>
+		<dependency>
+      		<groupId>org.springdoc</groupId>
+      		<artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+      		<version>2.8.10</version>
+   		</dependency>
+		
+		<!-- Dependências para geração de relatórios -->
+		<dependency>
+			<groupId>com.itextpdf</groupId>
+			<artifactId>itext7-core</artifactId>
+			<version>7.2.5</version>
+			<type>pom</type>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi</artifactId>
+			<version>5.2.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi-ooxml</artifactId>
+			<version>5.2.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.poi</groupId>
+			<artifactId>poi-ooxml-schemas</artifactId>
+			<version>4.1.2</version>
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/com/eduardo/HoneyPot/controller/ReportController.java
+++ b/src/main/java/com/eduardo/HoneyPot/controller/ReportController.java
@@ -1,0 +1,175 @@
+package com.eduardo.HoneyPot.controller;
+
+import com.eduardo.HoneyPot.service.ReportService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@RestController
+@RequestMapping("/api/reports")
+@Slf4j
+public class ReportController {
+    
+    @Autowired
+    private ReportService reportService;
+    
+    /**
+     * Gera relatório de ataques em PDF
+     */
+    @GetMapping("/attacks/pdf")
+    public ResponseEntity<byte[]> generateAttackReportPDF() {
+        try {
+            log.info("Gerando relatório de ataques em PDF...");
+            byte[] pdfContent = reportService.generateAttackReportPDF();
+            
+            String filename = "relatorio_ataques_" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")) + ".pdf";
+            
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_PDF);
+            headers.setContentDispositionFormData("attachment", filename);
+            
+            log.info("Relatório PDF gerado com sucesso: {} bytes", pdfContent.length);
+            return ResponseEntity.ok()
+                .headers(headers)
+                .body(pdfContent);
+                
+        } catch (Exception e) {
+            log.error("Erro ao gerar relatório PDF: {}", e.getMessage());
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+    
+    /**
+     * Gera relatório de ataques em Excel
+     */
+    @GetMapping("/attacks/excel")
+    public ResponseEntity<byte[]> generateAttackReportExcel() {
+        try {
+            log.info("Gerando relatório de ataques em Excel...");
+            byte[] excelContent = reportService.generateAttackReportExcel();
+            
+            String filename = "relatorio_ataques_" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")) + ".xlsx";
+            
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+            headers.setContentDispositionFormData("attachment", filename);
+            
+            log.info("Relatório Excel gerado com sucesso: {} bytes", excelContent.length);
+            return ResponseEntity.ok()
+                .headers(headers)
+                .body(excelContent);
+                
+        } catch (Exception e) {
+            log.error("Erro ao gerar relatório Excel: {}", e.getMessage());
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+    
+    /**
+     * Gera relatório de estatísticas em Excel
+     */
+    @GetMapping("/statistics/excel")
+    public ResponseEntity<byte[]> generateStatisticsReportExcel() {
+        try {
+            log.info("Gerando relatório de estatísticas em Excel...");
+            byte[] excelContent = reportService.generateStatisticsReportExcel();
+            
+            String filename = "relatorio_estatisticas_" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")) + ".xlsx";
+            
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+            headers.setContentDispositionFormData("attachment", filename);
+            
+            log.info("Relatório de estatísticas Excel gerado com sucesso: {} bytes", excelContent.length);
+            return ResponseEntity.ok()
+                .headers(headers)
+                .body(excelContent);
+                
+        } catch (Exception e) {
+            log.error("Erro ao gerar relatório de estatísticas: {}", e.getMessage());
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+    
+    /**
+     * Gera relatório de notificações em Excel
+     */
+    @GetMapping("/notifications/excel")
+    public ResponseEntity<byte[]> generateNotificationsReportExcel() {
+        try {
+            log.info("Gerando relatório de notificações em Excel...");
+            byte[] excelContent = reportService.generateNotificationsReportExcel();
+            
+            String filename = "relatorio_notificacoes_" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")) + ".xlsx";
+            
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+            headers.setContentDispositionFormData("attachment", filename);
+            
+            log.info("Relatório de notificações Excel gerado com sucesso: {} bytes", excelContent.length);
+            return ResponseEntity.ok()
+                .headers(headers)
+                .body(excelContent);
+                
+        } catch (Exception e) {
+            log.error("Erro ao gerar relatório de notificações: {}", e.getMessage());
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+    
+    /**
+     * Gera relatório consolidado em Excel (todas as informações)
+     */
+    @GetMapping("/consolidated/excel")
+    public ResponseEntity<byte[]> generateConsolidatedReportExcel() {
+        try {
+            log.info("Gerando relatório consolidado em Excel...");
+            byte[] excelContent = reportService.generateConsolidatedReportExcel();
+            
+            String filename = "relatorio_consolidado_" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")) + ".xlsx";
+            
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"));
+            headers.setContentDispositionFormData("attachment", filename);
+            
+            log.info("Relatório consolidado Excel gerado com sucesso: {} bytes", excelContent.length);
+            return ResponseEntity.ok()
+                .headers(headers)
+                .body(excelContent);
+                
+        } catch (Exception e) {
+            log.error("Erro ao gerar relatório consolidado: {}", e.getMessage());
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+    
+    /**
+     * Gera todos os relatórios disponíveis
+     */
+    @GetMapping("/all")
+    public ResponseEntity<String> generateAllReports() {
+        try {
+            log.info("Gerando todos os relatórios disponíveis...");
+            
+            // Gerar todos os relatórios
+            reportService.generateAttackReportPDF();
+            reportService.generateAttackReportExcel();
+            reportService.generateStatisticsReportExcel();
+            reportService.generateNotificationsReportExcel();
+            reportService.generateConsolidatedReportExcel();
+            
+            log.info("Todos os relatórios foram gerados com sucesso");
+            return ResponseEntity.ok("Todos os relatórios foram gerados com sucesso");
+            
+        } catch (Exception e) {
+            log.error("Erro ao gerar todos os relatórios: {}", e.getMessage());
+            return ResponseEntity.internalServerError().body("Erro ao gerar relatórios: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/eduardo/HoneyPot/service/ReportService.java
+++ b/src/main/java/com/eduardo/HoneyPot/service/ReportService.java
@@ -5,6 +5,11 @@ import com.eduardo.HoneyPot.model.CommandExecution;
 import com.eduardo.HoneyPot.model.Notification;
 import com.eduardo.HoneyPot.repository.AttackLogRepository;
 import com.eduardo.HoneyPot.repository.NotificationRepository;
+import com.itextpdf.kernel.pdf.PdfDocument;
+import com.itextpdf.kernel.pdf.PdfWriter;
+import com.itextpdf.layout.Document;
+import com.itextpdf.layout.element.Paragraph;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
@@ -513,16 +518,37 @@ public class ReportService {
     }
     
     private byte[] generateBasicPDFReport(List<AttackLog> attacks) {
-        // Implementação básica de PDF (placeholder)
-        // Em uma implementação real, usaríamos iText7 para criar um PDF completo
-        String reportContent = "Relatório de Ataques Honeypot\n";
-        reportContent += "Data: " + LocalDateTime.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss")) + "\n";
-        reportContent += "Total de Ataques: " + attacks.size() + "\n\n";
-        
-        for (AttackLog attack : attacks) {
-            reportContent += "IP: " + attack.getSourceIp() + " | Protocolo: " + attack.getProtocol() + " | Data: " + formatDateTime(attack.getTimestamp()) + "\n";
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            PdfWriter writer = new PdfWriter(outputStream);
+            PdfDocument pdf = new PdfDocument(writer);
+            Document document = new Document(pdf);
+    
+            // Título
+            document.add(new Paragraph("Relatório de Ataques Honeypot")
+                    .setBold()
+                    .setFontSize(16));
+    
+            document.add(new Paragraph("Data de Geração: " +
+                    LocalDateTime.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss"))));
+    
+            document.add(new Paragraph("Total de Ataques: " + attacks.size()));
+            document.add(new Paragraph("\n"));
+    
+            // Lista de ataques
+            for (AttackLog attack : attacks) {
+                document.add(new Paragraph(
+                    "IP: " + attack.getSourceIp() +
+                    " | Protocolo: " + attack.getProtocol() +
+                    " | Data: " + formatDateTime(attack.getTimestamp())
+                ));
+            }
+    
+            document.close();
+            return outputStream.toByteArray();
+        } catch (Exception e) {
+            log.error("Erro ao gerar PDF: {}", e.getMessage());
+            return new byte[0];
         }
-        
-        return reportContent.getBytes();
     }
+    
 }

--- a/src/main/java/com/eduardo/HoneyPot/service/ReportService.java
+++ b/src/main/java/com/eduardo/HoneyPot/service/ReportService.java
@@ -1,0 +1,528 @@
+package com.eduardo.HoneyPot.service;
+
+import com.eduardo.HoneyPot.model.AttackLog;
+import com.eduardo.HoneyPot.model.CommandExecution;
+import com.eduardo.HoneyPot.model.Notification;
+import com.eduardo.HoneyPot.repository.AttackLogRepository;
+import com.eduardo.HoneyPot.repository.NotificationRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class ReportService {
+    
+    @Autowired
+    private AttackLogRepository attackLogRepository;
+    
+    @Autowired
+    private NotificationRepository notificationRepository;
+    
+    @Autowired
+    private StatisticsService statisticsService;
+    
+    /**
+     * Gera relatório PDF dos ataques
+     */
+    public byte[] generateAttackReportPDF() {
+        try {
+            List<AttackLog> attacks = attackLogRepository.findAll();
+            
+            // Implementação do PDF será feita com iText7
+            // Por enquanto retornamos um PDF básico
+            return generateBasicPDFReport(attacks);
+            
+        } catch (Exception e) {
+            log.error("Erro ao gerar relatório PDF: {}", e.getMessage());
+            return new byte[0];
+        }
+    }
+    
+    /**
+     * Gera relatório Excel dos ataques
+     */
+    public byte[] generateAttackReportExcel() {
+        try (Workbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("Relatório de Ataques");
+            
+            // Cabeçalho
+            Row headerRow = sheet.createRow(0);
+            String[] headers = {"Data/Hora", "IP Atacante", "Porta", "Protocolo", "Usuário", "Senha", "Banner", "Comandos", "Sucesso"};
+            
+            CellStyle headerStyle = createHeaderStyle(workbook);
+            for (int i = 0; i < headers.length; i++) {
+                Cell cell = headerRow.createCell(i);
+                cell.setCellValue(headers[i]);
+                cell.setCellStyle(headerStyle);
+                sheet.autoSizeColumn(i);
+            }
+            
+            // Dados dos ataques
+            List<AttackLog> attacks = attackLogRepository.findAll();
+            int rowNum = 1;
+            
+            for (AttackLog attack : attacks) {
+                Row row = sheet.createRow(rowNum++);
+                
+                row.createCell(0).setCellValue(formatDateTime(attack.getTimestamp()));
+                row.createCell(1).setCellValue(attack.getSourceIp());
+                row.createCell(2).setCellValue(attack.getPort());
+                row.createCell(3).setCellValue(attack.getProtocol());
+                row.createCell(4).setCellValue(attack.getUsername() != null ? attack.getUsername() : "");
+                row.createCell(5).setCellValue(attack.getPassword() != null ? attack.getPassword() : "");
+                row.createCell(6).setCellValue(attack.getBanner() != null ? attack.getBanner() : "");
+                row.createCell(7).setCellValue(formatCommands(attack.getCommands()));
+                row.createCell(8).setCellValue(attack.isSuccessful() ? "Sim" : "Não");
+            }
+            
+            // Auto-dimensionar colunas
+            for (int i = 0; i < headers.length; i++) {
+                sheet.autoSizeColumn(i);
+            }
+            
+            // Converter para byte array
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            workbook.write(outputStream);
+            return outputStream.toByteArray();
+            
+        } catch (IOException e) {
+            log.error("Erro ao gerar relatório Excel: {}", e.getMessage());
+            return new byte[0];
+        }
+    }
+    
+    /**
+     * Gera relatório de estatísticas em Excel
+     */
+    public byte[] generateStatisticsReportExcel() {
+        try (Workbook workbook = new XSSFWorkbook()) {
+            
+            // Aba 1: Resumo Geral
+            Sheet summarySheet = workbook.createSheet("Resumo Geral");
+            createSummarySheet(summarySheet);
+            
+            // Aba 2: Ataques por Protocolo
+            Sheet protocolSheet = workbook.createSheet("Ataques por Protocolo");
+            createProtocolAnalysisSheet(protocolSheet);
+            
+            // Aba 3: Top IPs Atacantes
+            Sheet topIpsSheet = workbook.createSheet("Top IPs Atacantes");
+            createTopIpsSheet(topIpsSheet);
+            
+            // Aba 4: Comandos Mais Executados
+            Sheet commandsSheet = workbook.createSheet("Comandos Executados");
+            createCommandsAnalysisSheet(commandsSheet);
+            
+            // Aba 5: Timeline de Ataques
+            Sheet timelineSheet = workbook.createSheet("Timeline de Ataques");
+            createTimelineSheet(timelineSheet);
+            
+            // Converter para byte array
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            workbook.write(outputStream);
+            return outputStream.toByteArray();
+            
+        } catch (IOException e) {
+            log.error("Erro ao gerar relatório de estatísticas: {}", e.getMessage());
+            return new byte[0];
+        }
+    }
+    
+    /**
+     * Gera relatório de notificações em Excel
+     */
+    public byte[] generateNotificationsReportExcel() {
+        try (Workbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("Relatório de Notificações");
+            
+            // Cabeçalho
+            Row headerRow = sheet.createRow(0);
+            String[] headers = {"Data/Hora", "Tipo", "Título", "Mensagem", "IP Atacante", "Protocolo", "Usuário"};
+            
+            CellStyle headerStyle = createHeaderStyle(workbook);
+            for (int i = 0; i < headers.length; i++) {
+                Cell cell = headerRow.createCell(i);
+                cell.setCellValue(headers[i]);
+                cell.setCellStyle(headerStyle);
+                sheet.autoSizeColumn(i);
+            }
+            
+            // Dados das notificações
+            List<Notification> notifications = notificationRepository.findAll();
+            int rowNum = 1;
+            
+            for (Notification notification : notifications) {
+                Row row = sheet.createRow(rowNum++);
+                
+                row.createCell(0).setCellValue(formatDateTime(notification.getTimestamp()));
+                row.createCell(1).setCellValue(notification.getType());
+                row.createCell(2).setCellValue(notification.getTitle());
+                row.createCell(3).setCellValue(notification.getMessage());
+                row.createCell(4).setCellValue(notification.getSourceIp() != null ? notification.getSourceIp() : "");
+                row.createCell(5).setCellValue(notification.getProtocol() != null ? notification.getProtocol() : "");
+                row.createCell(6).setCellValue(notification.getUsername() != null ? notification.getUsername() : "");
+            }
+            
+            // Auto-dimensionar colunas
+            for (int i = 0; i < headers.length; i++) {
+                sheet.autoSizeColumn(i);
+            }
+            
+            // Converter para byte array
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            workbook.write(outputStream);
+            return outputStream.toByteArray();
+            
+        } catch (IOException e) {
+            log.error("Erro ao gerar relatório de notificações: {}", e.getMessage());
+            return new byte[0];
+        }
+    }
+    
+    /**
+     * Gera relatório consolidado (todas as informações)
+     */
+    public byte[] generateConsolidatedReportExcel() {
+        try (Workbook workbook = new XSSFWorkbook()) {
+            
+            // Aba 1: Dashboard Executivo
+            Sheet dashboardSheet = workbook.createSheet("Dashboard Executivo");
+            createDashboardSheet(dashboardSheet);
+            
+            // Aba 2: Detalhamento de Ataques
+            Sheet attacksSheet = workbook.createSheet("Detalhamento de Ataques");
+            createDetailedAttacksSheet(attacksSheet);
+            
+            // Aba 3: Análise de Comportamento
+            Sheet behaviorSheet = workbook.createSheet("Análise de Comportamento");
+            createBehaviorAnalysisSheet(behaviorSheet);
+            
+            // Aba 4: Notificações e Alertas
+            Sheet alertsSheet = workbook.createSheet("Notificações e Alertas");
+            createAlertsSheet(alertsSheet);
+            
+            // Aba 5: Recomendações de Segurança
+            Sheet recommendationsSheet = workbook.createSheet("Recomendações");
+            createRecommendationsSheet(recommendationsSheet);
+            
+            // Converter para byte array
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            workbook.write(outputStream);
+            return outputStream.toByteArray();
+            
+        } catch (IOException e) {
+            log.error("Erro ao gerar relatório consolidado: {}", e.getMessage());
+            return new byte[0];
+        }
+    }
+    
+    // Métodos auxiliares para criação das abas
+    private void createSummarySheet(Sheet sheet) {
+        Row headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("Métrica");
+        headerRow.createCell(1).setCellValue("Valor");
+        
+        List<AttackLog> attacks = attackLogRepository.findAll();
+        long totalAttacks = attacks.size();
+        long sshAttacks = attacks.stream().filter(a -> "SSH".equals(a.getProtocol())).count();
+        long telnetAttacks = attacks.stream().filter(a -> "TELNET".equals(a.getProtocol())).count();
+        
+        int rowNum = 1;
+        sheet.createRow(rowNum++).createCell(0).setCellValue("Total de Ataques");
+        sheet.getRow(rowNum-1).createCell(1).setCellValue(totalAttacks);
+        
+        sheet.createRow(rowNum++).createCell(0).setCellValue("Ataques SSH");
+        sheet.getRow(rowNum-1).createCell(1).setCellValue(sshAttacks);
+        
+        sheet.createRow(rowNum++).createCell(0).setCellValue("Ataques Telnet");
+        sheet.getRow(rowNum-1).createCell(1).setCellValue(telnetAttacks);
+        
+        sheet.createRow(rowNum++).createCell(0).setCellValue("Data de Geração");
+        sheet.getRow(rowNum-1).createCell(1).setCellValue(LocalDateTime.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss")));
+    }
+    
+    private void createProtocolAnalysisSheet(Sheet sheet) {
+        Row headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("Protocolo");
+        headerRow.createCell(1).setCellValue("Total de Ataques");
+        headerRow.createCell(2).setCellValue("Porcentagem");
+        
+        List<AttackLog> attacks = attackLogRepository.findAll();
+        long total = attacks.size();
+        
+        Map<String, Long> protocolCounts = attacks.stream()
+            .collect(Collectors.groupingBy(AttackLog::getProtocol, Collectors.counting()));
+        
+        int rowNum = 1;
+        for (Map.Entry<String, Long> entry : protocolCounts.entrySet()) {
+            Row row = sheet.createRow(rowNum++);
+            row.createCell(0).setCellValue(entry.getKey());
+            row.createCell(1).setCellValue(entry.getValue());
+            row.createCell(2).setCellValue(String.format("%.2f%%", (entry.getValue() * 100.0) / total));
+        }
+    }
+    
+    private void createTopIpsSheet(Sheet sheet) {
+        Row headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("IP Atacante");
+        headerRow.createCell(1).setCellValue("Total de Tentativas");
+        headerRow.createCell(2).setCellValue("Última Tentativa");
+        
+        List<AttackLog> attacks = attackLogRepository.findAll();
+        Map<String, Long> ipCounts = attacks.stream()
+            .collect(Collectors.groupingBy(AttackLog::getSourceIp, Collectors.counting()));
+        
+        int rowNum = 1;
+        for (Map.Entry<String, Long> entry : ipCounts.entrySet()) {
+            Row row = sheet.createRow(rowNum++);
+            row.createCell(0).setCellValue(entry.getKey());
+            row.createCell(1).setCellValue(entry.getValue());
+            
+            // Encontrar última tentativa deste IP
+            LocalDateTime lastAttempt = attacks.stream()
+                .filter(a -> entry.getKey().equals(a.getSourceIp()))
+                .map(AttackLog::getTimestamp)
+                .max(LocalDateTime::compareTo)
+                .orElse(null);
+            
+            row.createCell(2).setCellValue(lastAttempt != null ? formatDateTime(lastAttempt) : "");
+        }
+    }
+    
+    private void createCommandsAnalysisSheet(Sheet sheet) {
+        Row headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("Comando");
+        headerRow.createCell(1).setCellValue("Total de Execuções");
+        headerRow.createCell(2).setCellValue("IPs Únicos");
+        
+        List<AttackLog> attacks = attackLogRepository.findAll();
+        Map<String, Long> commandCounts = new java.util.HashMap<>();
+        Map<String, java.util.Set<String>> commandIps = new java.util.HashMap<>();
+        
+                    for (AttackLog attack : attacks) {
+                if (attack.getCommands() != null) {
+                    for (CommandExecution command : attack.getCommands()) {
+                        commandCounts.merge(command.getCommand(), 1L, Long::sum);
+                        commandIps.computeIfAbsent(command.getCommand(), k -> new java.util.HashSet<>()).add(attack.getSourceIp());
+                    }
+                }
+            }
+        
+        int rowNum = 1;
+        for (Map.Entry<String, Long> entry : commandCounts.entrySet()) {
+            Row row = sheet.createRow(rowNum++);
+            row.createCell(0).setCellValue(entry.getKey());
+            row.createCell(1).setCellValue(entry.getValue());
+            row.createCell(2).setCellValue(commandIps.get(entry.getKey()).size());
+        }
+    }
+    
+    private void createTimelineSheet(Sheet sheet) {
+        Row headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("Data/Hora");
+        headerRow.createCell(1).setCellValue("IP Atacante");
+        headerRow.createCell(2).setCellValue("Protocolo");
+        headerRow.createCell(3).setCellValue("Ação");
+        
+        List<AttackLog> attacks = attackLogRepository.findAll();
+        attacks.sort((a1, a2) -> a1.getTimestamp().compareTo(a2.getTimestamp()));
+        
+        int rowNum = 1;
+        for (AttackLog attack : attacks) {
+            Row row = sheet.createRow(rowNum++);
+            row.createCell(0).setCellValue(formatDateTime(attack.getTimestamp()));
+            row.createCell(1).setCellValue(attack.getSourceIp());
+            row.createCell(2).setCellValue(attack.getProtocol());
+            row.createCell(3).setCellValue("Tentativa de Conexão");
+        }
+    }
+    
+    private void createDashboardSheet(Sheet sheet) {
+        // Dashboard executivo com gráficos e métricas principais
+        Row titleRow = sheet.createRow(0);
+        titleRow.createCell(0).setCellValue("DASHBOARD EXECUTIVO - HONEYPOT");
+        
+        Row subtitleRow = sheet.createRow(1);
+        subtitleRow.createCell(0).setCellValue("Relatório de Segurança e Monitoramento");
+        
+        // Métricas principais
+        List<AttackLog> attacks = attackLogRepository.findAll();
+        long totalAttacks = attacks.size();
+        long uniqueIps = attacks.stream().map(AttackLog::getSourceIp).distinct().count();
+        
+        Row metric1Row = sheet.createRow(3);
+        metric1Row.createCell(0).setCellValue("Total de Ataques Detectados:");
+        metric1Row.createCell(1).setCellValue(totalAttacks);
+        
+        Row metric2Row = sheet.createRow(4);
+        metric2Row.createCell(0).setCellValue("IPs Únicos Atacantes:");
+        metric2Row.createCell(1).setCellValue(uniqueIps);
+        
+        Row metric3Row = sheet.createRow(5);
+        metric3Row.createCell(0).setCellValue("Período de Monitoramento:");
+        metric3Row.createCell(1).setCellValue("Ativo");
+        
+        Row metric4Row = sheet.createRow(6);
+        metric4Row.createCell(0).setCellValue("Data de Geração:");
+        metric4Row.createCell(1).setCellValue(LocalDateTime.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss")));
+    }
+    
+    private void createDetailedAttacksSheet(Sheet sheet) {
+        Row headerRow = sheet.createRow(0);
+        String[] headers = {"Data/Hora", "IP Atacante", "Porta", "Protocolo", "Usuário", "Senha", "Comandos", "Sucesso"};
+        
+        for (int i = 0; i < headers.length; i++) {
+            headerRow.createCell(i).setCellValue(headers[i]);
+        }
+        
+        List<AttackLog> attacks = attackLogRepository.findAll();
+        int rowNum = 1;
+        
+        for (AttackLog attack : attacks) {
+            Row row = sheet.createRow(rowNum++);
+            row.createCell(0).setCellValue(formatDateTime(attack.getTimestamp()));
+            row.createCell(1).setCellValue(attack.getSourceIp());
+            row.createCell(2).setCellValue(attack.getPort());
+            row.createCell(3).setCellValue(attack.getProtocol());
+            row.createCell(4).setCellValue(attack.getUsername() != null ? attack.getUsername() : "");
+            row.createCell(5).setCellValue(attack.getPassword() != null ? attack.getPassword() : "");
+            row.createCell(6).setCellValue(formatCommands(attack.getCommands()));
+            row.createCell(7).setCellValue(attack.isSuccessful() ? "Sim" : "Não");
+        }
+    }
+    
+    private void createBehaviorAnalysisSheet(Sheet sheet) {
+        Row headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("Padrão de Comportamento");
+        headerRow.createCell(1).setCellValue("Descrição");
+        headerRow.createCell(2).setCellValue("Frequência");
+        
+        List<AttackLog> attacks = attackLogRepository.findAll();
+        
+        // Análise de padrões
+        int rowNum = 1;
+        
+        // Padrão 1: Múltiplas tentativas do mesmo IP
+        Map<String, Long> ipAttempts = attacks.stream()
+            .collect(Collectors.groupingBy(AttackLog::getSourceIp, Collectors.counting()));
+        
+        long multipleAttempts = ipAttempts.values().stream().filter(count -> count > 1).count();
+        Row pattern1Row = sheet.createRow(rowNum++);
+        pattern1Row.createCell(0).setCellValue("Múltiplas Tentativas");
+        pattern1Row.createCell(1).setCellValue("IPs com mais de uma tentativa de conexão");
+        pattern1Row.createCell(2).setCellValue(multipleAttempts);
+        
+        // Padrão 2: Comandos de reconhecimento
+        long reconnaissanceCommands = attacks.stream()
+            .filter(a -> a.getCommands() != null)
+            .flatMap(a -> a.getCommands().stream())
+            .filter(cmd -> cmd.getCommand().startsWith("netstat") || cmd.getCommand().startsWith("ss") || cmd.getCommand().startsWith("ps"))
+            .count();
+        
+        Row pattern2Row = sheet.createRow(rowNum++);
+        pattern2Row.createCell(0).setCellValue("Comandos de Reconhecimento");
+        pattern2Row.createCell(1).setCellValue("Comandos para análise do sistema");
+        pattern2Row.createCell(2).setCellValue(reconnaissanceCommands);
+    }
+    
+    private void createAlertsSheet(Sheet sheet) {
+        Row headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("Tipo de Alerta");
+        headerRow.createCell(1).setCellValue("Descrição");
+        headerRow.createCell(2).setCellValue("Recomendação");
+        
+        int rowNum = 1;
+        
+        Row alert1Row = sheet.createRow(rowNum++);
+        alert1Row.createCell(0).setCellValue("Comandos Críticos");
+        alert1Row.createCell(1).setCellValue("Execução de comandos perigosos");
+        alert1Row.createCell(2).setCellValue("Monitorar e bloquear IPs suspeitos");
+        
+        Row alert2Row = sheet.createRow(rowNum++);
+        alert2Row.createCell(0).setCellValue("Tentativas de Download");
+        alert2Row.createCell(1).setCellValue("Tentativas de baixar arquivos");
+        alert2Row.createCell(2).setCellValue("Implementar filtros de rede");
+        
+        Row alert3Row = sheet.createRow(rowNum++);
+        alert3Row.createCell(0).setCellValue("Acesso a Arquivos Sensíveis");
+        alert3Row.createCell(1).setCellValue("Tentativas de leitura de arquivos do sistema");
+        alert3Row.createCell(2).setCellValue("Auditar permissões de arquivos");
+    }
+    
+    private void createRecommendationsSheet(Sheet sheet) {
+        Row headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue("Recomendação");
+        headerRow.createCell(1).setCellValue("Prioridade");
+        headerRow.createCell(2).setCellValue("Descrição");
+        
+        int rowNum = 1;
+        
+        Row rec1Row = sheet.createRow(rowNum++);
+        rec1Row.createCell(0).setCellValue("Implementar Rate Limiting");
+        rec1Row.createCell(1).setCellValue("ALTA");
+        rec1Row.createCell(2).setCellValue("Limitar tentativas de conexão por IP");
+        
+        Row rec2Row = sheet.createRow(rowNum++);
+        rec2Row.createCell(0).setCellValue("Configurar Firewall");
+        rec2Row.createCell(1).setCellValue("ALTA");
+        rec2Row.createCell(2).setCellValue("Bloquear IPs maliciosos automaticamente");
+        
+        Row rec3Row = sheet.createRow(rowNum++);
+        rec3Row.createCell(0).setCellValue("Monitoramento 24/7");
+        rec3Row.createCell(1).setCellValue("MÉDIA");
+        rec3Row.createCell(2).setCellValue("Implementar alertas em tempo real");
+        
+        Row rec4Row = sheet.createRow(rowNum++);
+        rec4Row.createCell(0).setCellValue("Backup de Logs");
+        rec4Row.createCell(1).setCellValue("MÉDIA");
+        rec4Row.createCell(2).setCellValue("Backup automático dos logs de ataque");
+    }
+    
+    // Métodos auxiliares
+    private CellStyle createHeaderStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+        Font font = workbook.createFont();
+        font.setBold(true);
+        style.setFont(font);
+        style.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.getIndex());
+        style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+        return style;
+    }
+    
+    private String formatDateTime(LocalDateTime dateTime) {
+        if (dateTime == null) return "";
+        return dateTime.format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss"));
+    }
+    
+    private String formatCommands(List<CommandExecution> commands) {
+        if (commands == null || commands.isEmpty()) return "";
+        return commands.stream()
+            .map(CommandExecution::getCommand)
+            .collect(Collectors.joining("; "));
+    }
+    
+    private byte[] generateBasicPDFReport(List<AttackLog> attacks) {
+        // Implementação básica de PDF (placeholder)
+        // Em uma implementação real, usaríamos iText7 para criar um PDF completo
+        String reportContent = "Relatório de Ataques Honeypot\n";
+        reportContent += "Data: " + LocalDateTime.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss")) + "\n";
+        reportContent += "Total de Ataques: " + attacks.size() + "\n\n";
+        
+        for (AttackLog attack : attacks) {
+            reportContent += "IP: " + attack.getSourceIp() + " | Protocolo: " + attack.getProtocol() + " | Data: " + formatDateTime(attack.getTimestamp()) + "\n";
+        }
+        
+        return reportContent.getBytes();
+    }
+}

--- a/src/main/java/com/eduardo/HoneyPot/service/ReportService.java
+++ b/src/main/java/com/eduardo/HoneyPot/service/ReportService.java
@@ -534,6 +534,7 @@ public class ReportService {
             PdfDocument pdf = new PdfDocument(writer);
             Document document = new Document(pdf, PageSize.A4);
     
+            // Margens reduzidas para melhor aproveitamento do espaço
             document.setMargins(25, 25, 25, 25);
     
             // Fonte

--- a/src/main/resources/static/dashboard-integration.css
+++ b/src/main/resources/static/dashboard-integration.css
@@ -762,3 +762,159 @@
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+/* ===== RELATÓRIOS PANEL ===== */
+
+.reports-panel {
+  margin-bottom: 2rem;
+}
+
+.reports-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.report-category {
+  background: var(--gray-50);
+  border: 1px solid var(--gray-200);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  transition: all 0.2s ease;
+}
+
+.report-category:hover {
+  border-color: var(--primary-color);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.1);
+}
+
+.report-category h3 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--gray-900);
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.report-buttons {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.report-buttons .btn {
+  flex: 1;
+  min-width: 80px;
+  justify-content: center;
+}
+
+.reports-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--gray-200);
+}
+
+.btn-large {
+  padding: 1rem 2rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.reports-status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+#reports-status-text {
+  font-size: 0.875rem;
+  color: var(--gray-600);
+  text-align: center;
+}
+
+.progress-bar {
+  width: 100%;
+  max-width: 400px;
+  height: 8px;
+  background-color: var(--gray-200);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--primary-color), var(--success-color));
+  width: 0%;
+  transition: width 0.3s ease;
+  animation: progress-animation 2s ease-in-out infinite;
+}
+
+@keyframes progress-animation {
+  0%, 100% { width: 0%; }
+  50% { width: 100%; }
+}
+
+/* Responsive Reports */
+@media (max-width: 768px) {
+  .reports-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+  
+  .report-category {
+    padding: 1rem;
+  }
+  
+  .report-buttons {
+    flex-direction: column;
+  }
+  
+  .report-buttons .btn {
+    width: 100%;
+  }
+  
+  .btn-large {
+    padding: 0.875rem 1.5rem;
+    font-size: 1rem;
+  }
+}
+
+/* Report Generation States */
+.report-category.generating {
+  border-color: var(--primary-color);
+  background-color: rgba(59, 130, 246, 0.05);
+}
+
+.report-category.generating h3::after {
+  content: "⏳";
+  margin-left: 0.5rem;
+  animation: spin 1s linear infinite;
+}
+
+.report-category.success {
+  border-color: var(--success-color);
+  background-color: rgba(34, 197, 94, 0.05);
+}
+
+.report-category.success h3::after {
+  content: "✅";
+  margin-left: 0.5rem;
+}
+
+.report-category.error {
+  border-color: var(--danger-color);
+  background-color: rgba(239, 68, 68, 0.05);
+}
+
+.report-category.error h3::after {
+  content: "❌";
+  margin-left: 0.5rem;
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -59,6 +59,67 @@
             </div>
         </section>
 
+        <!-- Reports Panel -->
+        <section class="reports-panel">
+            <div class="card">
+                <div class="card-header">
+                    <h2>Geração de Relatórios</h2>
+                    <p>Gere relatórios detalhados em PDF e Excel</p>
+                </div>
+                <div class="reports-grid">
+                    <div class="report-category">
+                        <h3>Relatórios de Ataques</h3>
+                        <div class="report-buttons">
+                            <button id="pdf-attacks-btn" class="btn btn-danger">
+                                PDF
+                            </button>
+                            <button id="excel-attacks-btn" class="btn btn-success">
+                                Excel
+                            </button>
+                        </div>
+                    </div>
+                    
+                    <div class="report-category">
+                        <h3>Relatórios de Estatísticas</h3>
+                        <div class="report-buttons">
+                            <button id="excel-stats-btn" class="btn btn-primary">
+                                Excel
+                            </button>
+                        </div>
+                    </div>
+                    
+                    <div class="report-category">
+                        <h3>Relatórios de Notificações</h3>
+                        <div class="report-buttons">
+                            <button id="excel-notifications-btn" class="btn btn-warning">
+                                Excel
+                            </button>
+                        </div>
+                    </div>
+                    
+                    <div class="report-category">
+                        <h3>Relatório Consolidado</h3>
+                        <div class="report-buttons">
+                            <button id="excel-consolidated-btn" class="btn btn-info">
+                                Excel
+                            </button>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="reports-actions">
+                    <button id="generate-all-reports-btn" class="btn btn-secondary btn-large">
+                        Gerar Todos os Relatórios
+                    </button>
+                    <div class="reports-status">
+                        <div id="reports-progress" class="progress-bar" style="display: none;">
+                            <div class="progress-fill"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
         <!-- Notifications Panel -->
         <section class="notifications-panel">
             <div class="card">

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -1,709 +1,948 @@
 /* Modern Security Dashboard Styles - Integração com API */
 
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
-  
-  :root {
-    /* Professional Color Palette */
-    --primary-color: #2563eb;
-    --primary-light: #3b82f6;
-    --secondary-color: #64748b;
-    --accent-color: #f59e0b;
-  
-    /* Status Colors */
-    --success-color: #10b981;
-    --danger-color: #ef4444;
-    --warning-color: #f59e0b;
-    --info-color: #06b6d4;
-  
-    /* Neutral Colors */
-    --gray-50: #f8fafc;
-    --gray-100: #f1f5f9;
-    --gray-200: #e2e8f0;
-    --gray-300: #cbd5e1;
-    --gray-400: #94a3b8;
-    --gray-500: #64748b;
-    --gray-600: #475569;
-    --gray-700: #334155;
-    --gray-800: #1e293b;
-    --gray-900: #0f172a;
-  
-    /* Background */
-    --bg-primary: #ffffff;
-    --bg-secondary: var(--gray-50);
-    --bg-tertiary: var(--gray-100);
-  
-    /* Shadows */
-    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-    --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-  
-    /* Border Radius */
-    --radius-sm: 0.375rem;
-    --radius: 0.5rem;
-    --radius-md: 0.75rem;
-    --radius-lg: 1rem;
-    --radius-xl: 1.5rem;
-  
-    /* Typography */
-    --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    --font-mono: "SF Mono", Monaco, Inconsolata, "Roboto Mono", monospace;
+
+:root {
+  /* Professional Color Palette */
+  --primary-color: #2563eb;
+  --primary-light: #3b82f6;
+  --secondary-color: #64748b;
+  --accent-color: #f59e0b;
+
+  /* Status Colors */
+  --success-color: #10b981;
+  --danger-color: #ef4444;
+  --warning-color: #f59e0b;
+  --info-color: #06b6d4;
+
+  /* Neutral Colors */
+  --gray-50: #f8fafc;
+  --gray-100: #f1f5f9;
+  --gray-200: #e2e8f0;
+  --gray-300: #cbd5e1;
+  --gray-400: #94a3b8;
+  --gray-500: #64748b;
+  --gray-600: #475569;
+  --gray-700: #334155;
+  --gray-800: #1e293b;
+  --gray-900: #0f172a;
+
+  /* Background */
+  --bg-primary: #ffffff;
+  --bg-secondary: var(--gray-50);
+  --bg-tertiary: var(--gray-100);
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+
+  /* Border Radius */
+  --radius-sm: 0.375rem;
+  --radius: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.5rem;
+
+  /* Typography */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "SF Mono", Monaco, Inconsolata, "Roboto Mono", monospace;
+
+  /* Standardized padding variables for consistency */
+  --padding-xs: 0.75rem;
+  --padding-sm: 1rem;
+  --padding-md: 1.5rem;
+  --padding-lg: 2rem;
+  --padding-xl: 2.5rem;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--bg-secondary);
+  color: var(--gray-900);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.container {
+  max-width: 1400px;
+  margin: 0 auto;
+  /* Standardized container padding */
+  padding: var(--padding-md);
+}
+
+/* Header */
+.header {
+  background: var(--bg-primary);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow);
+  margin-bottom: 2rem;
+  border: 1px solid var(--gray-200);
+}
+
+.header-content {
+  /* Standardized header padding and centered alignment */
+  padding: var(--padding-lg);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  text-align: center;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  /* Center align header content */
+  text-align: center;
+}
+
+.header-icon {
+  font-size: 2.5rem;
+  background: linear-gradient(135deg, var(--primary-color), var(--primary-light));
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.header-text h1 {
+  font-size: 1.875rem;
+  font-weight: 700;
+  color: var(--gray-900);
+  margin-bottom: 0.25rem;
+  /* Center align header text */
+  text-align: center;
+}
+
+.header-text p {
+  color: var(--gray-600);
+  font-size: 0.875rem;
+  /* Center align header subtitle */
+  text-align: center;
+}
+
+.status-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: var(--bg-tertiary);
+  /* Standardized status indicator padding */
+  padding: var(--padding-sm) var(--padding-md);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--gray-200);
+}
+
+.status-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  animation: pulse 2s infinite;
+}
+
+.status-dot.online {
+  background-color: var(--success-color);
+}
+
+.status-dot.offline {
+  background-color: var(--danger-color);
+}
+
+.status-text {
+  display: flex;
+  flex-direction: column;
+  /* Center align status text */
+  text-align: center;
+}
+
+.status-text span:first-child {
+  font-weight: 600;
+  color: var(--gray-900);
+  font-size: 0.875rem;
+}
+
+.status-subtitle {
+  font-size: 0.75rem;
+  color: var(--gray-500);
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
   }
-  
-  body {
-    font-family: var(--font-sans);
-    background: var(--bg-secondary);
-    color: var(--gray-900);
-    line-height: 1.6;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
-  
-  .container {
-    max-width: 1400px;
-    margin: 0 auto;
-    padding: 1.5rem;
-  }
-  
-  /* Header */
-  .header {
-    background: var(--bg-primary);
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow);
-    margin-bottom: 2rem;
-    border: 1px solid var(--gray-200);
-  }
-  
-  .header-content {
-    padding: 2rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-  
-  .header-left {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-  }
-  
-  .header-icon {
-    font-size: 2.5rem;
-    background: linear-gradient(135deg, var(--primary-color), var(--primary-light));
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-  }
-  
-  .header-text h1 {
-    font-size: 1.875rem;
-    font-weight: 700;
-    color: var(--gray-900);
-    margin-bottom: 0.25rem;
-  }
-  
-  .header-text p {
-    color: var(--gray-600);
-    font-size: 0.875rem;
-  }
-  
-  .status-indicator {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    background: var(--bg-tertiary);
-    padding: 1rem 1.5rem;
-    border-radius: var(--radius-lg);
-    border: 1px solid var(--gray-200);
-  }
-  
-  .status-dot {
-    width: 0.75rem;
-    height: 0.75rem;
-    border-radius: 50%;
-    animation: pulse 2s infinite;
-  }
-  
-  .status-dot.online {
-    background-color: var(--success-color);
-  }
-  
-  .status-dot.offline {
-    background-color: var(--danger-color);
-  }
-  
-  .status-text {
-    display: flex;
-    flex-direction: column;
-  }
-  
-  .status-text span:first-child {
-    font-weight: 600;
-    color: var(--gray-900);
-    font-size: 0.875rem;
-  }
-  
-  .status-subtitle {
-    font-size: 0.75rem;
-    color: var(--gray-500);
-  }
-  
-  @keyframes pulse {
-    0%,
-    100% {
-      opacity: 1;
-    }
-    50% {
-      opacity: 0.5;
-    }
-  }
-  
-  /* Cards */
-  .card {
-    background: var(--bg-primary);
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow);
-    border: 1px solid var(--gray-200);
-    transition: all 0.2s ease;
-  }
-  
-  .card:hover {
-    box-shadow: var(--shadow-md);
-  }
-  
-  .card-header {
-    padding: 1.5rem 1.5rem 0 1.5rem;
-  }
-  
-  .card-header h2,
-  .card-header h3 {
-    font-size: 1.125rem;
-    font-weight: 600;
-    color: var(--gray-900);
-    margin-bottom: 0.25rem;
-  }
-  
-  .card-header p {
-    color: var(--gray-600);
-    font-size: 0.875rem;
-  }
-  
-  /* Control Panel */
-  .control-panel {
-    margin-bottom: 2rem;
-  }
-  
-  .control-panel .card {
-    padding: 1.5rem;
-  }
-  
-  .control-buttons {
-    display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
-    margin-top: 1.5rem;
-  }
-  
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.75rem 1.5rem;
-    border: none;
-    border-radius: var(--radius);
-    font-weight: 500;
-    font-size: 0.875rem;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    text-decoration: none;
-  }
-  
-  .btn:hover {
-    transform: translateY(-1px);
-    box-shadow: var(--shadow-md);
-  }
-  
-  .btn:active {
-    transform: translateY(0);
-  }
-  
-  .btn-icon {
-    font-size: 1rem;
-  }
-  
-  .btn-success {
-    background: var(--success-color);
-    color: white;
-  }
-  
-  .btn-success:hover {
-    background: #059669;
-  }
-  
-  .btn-danger {
-    background: var(--danger-color);
-    color: white;
-  }
-  
-  .btn-danger:hover {
-    background: #dc2626;
-  }
-  
-  .btn-warning {
-    background: var(--warning-color);
-    color: white;
-  }
-  
-  .btn-warning:hover {
-    background: #d97706;
-  }
-  
-  .btn-primary {
-    background: var(--primary-color);
-    color: white;
-  }
-  
-  .btn-primary:hover {
-    background: var(--primary-light);
-  }
-  
-  .btn-secondary {
-    background: var(--gray-600);
-    color: white;
-  }
-  
-  .btn-secondary:hover {
-    background: var(--gray-700);
-  }
-  
-  .btn-danger-outline {
-    background: transparent;
-    color: var(--danger-color);
-    border: 1px solid var(--danger-color);
-  }
-  
-  .btn-danger-outline:hover {
-    background: var(--danger-color);
-    color: white;
-  }
-  
-  .btn:disabled {
+  50% {
     opacity: 0.5;
-    cursor: not-allowed;
-    transform: none;
   }
-  
-  /* Statistics Grid */
-  .stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 2rem;
+}
+
+/* Cards */
+.card {
+  background: var(--bg-primary);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--gray-200);
+  transition: all 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.card-header {
+  /* Standardized card header padding and centered text */
+  padding: var(--padding-md) var(--padding-md) 0 var(--padding-md);
+  text-align: center;
+}
+
+.card-header h2,
+.card-header h3 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--gray-900);
+  margin-bottom: 0.25rem;
+}
+
+.card-header p {
+  color: var(--gray-600);
+  font-size: 0.875rem;
+}
+
+/* Control Panel */
+.control-panel {
+  margin-bottom: 2rem;
+}
+
+.control-panel .card {
+  /* Standardized control panel padding */
+  padding: var(--padding-md);
+}
+
+.control-buttons {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: var(--padding-md);
+  /* Center align control buttons */
+  justify-content: center;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  /* Standardized button padding */
+  padding: var(--padding-xs) var(--padding-md);
+  border: none;
+  border-radius: var(--radius);
+  font-weight: 500;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-decoration: none;
+  /* Center align button text */
+  text-align: center;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.btn:active {
+  transform: translateY(0);
+}
+
+.btn-icon {
+  font-size: 1rem;
+}
+
+.btn-success {
+  background: var(--success-color);
+  color: white;
+}
+
+.btn-success:hover {
+  background: #059669;
+}
+
+.btn-danger {
+  background: var(--danger-color);
+  color: white;
+}
+
+.btn-danger:hover {
+  background: #dc2626;
+}
+
+.btn-warning {
+  background: var(--warning-color);
+  color: white;
+}
+
+.btn-warning:hover {
+  background: #d97706;
+}
+
+.btn-primary {
+  background: var(--primary-color);
+  color: white;
+}
+
+.btn-primary:hover {
+  background: var(--primary-light);
+}
+
+.btn-secondary {
+  background: var(--gray-600);
+  color: white;
+}
+
+.btn-secondary:hover {
+  background: var(--gray-700);
+}
+
+.btn-danger-outline {
+  background: transparent;
+  color: var(--danger-color);
+  border: 1px solid var(--danger-color);
+}
+
+.btn-danger-outline:hover {
+  background: var(--danger-color);
+  color: white;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+/* Reports Panel Styles */
+.reports-panel {
+  margin-bottom: 2rem;
+}
+
+.reports-panel .card {
+  padding: var(--padding-md);
+}
+
+.reports-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: var(--padding-md);
+  margin-top: var(--padding-md);
+}
+
+.report-category {
+  background: var(--bg-tertiary);
+  padding: var(--padding-md);
+  border-radius: var(--radius-lg);
+  text-align: center;
+}
+
+.report-category h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--gray-900);
+  margin-bottom: var(--padding-sm);
+}
+
+.report-buttons {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.reports-actions {
+  margin-top: var(--padding-lg);
+  text-align: center;
+}
+
+.btn-large {
+  padding: var(--padding-sm) var(--padding-lg);
+  font-size: 1rem;
+}
+
+/* Notifications Panel Styles */
+.notifications-panel {
+  margin-bottom: 2rem;
+}
+
+.notifications-panel .card {
+  padding: var(--padding-md);
+}
+
+.notifications-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--padding-sm);
+}
+
+.notifications-container {
+  margin-top: var(--padding-md);
+}
+
+.notifications-footer {
+  margin-top: var(--padding-md);
+  text-align: center;
+}
+
+.unread-badge {
+  background: var(--danger-color);
+  color: white;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+/* Statistics Grid */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.stat-card {
+  background: var(--bg-primary);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--gray-200);
+  /* Standardized stat card padding and centered content */
+  padding: var(--padding-md);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  transition: all 0.2s ease;
+  text-align: center;
+}
+
+.stat-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
+.stat-icon {
+  background: linear-gradient(135deg, var(--primary-color), var(--primary-light));
+  color: white;
+  /* Standardized stat icon padding */
+  padding: var(--padding-xs);
+  border-radius: var(--radius-lg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.stat-content {
+  flex: 1;
+  /* Center align stat content */
+  text-align: center;
+}
+
+.stat-content h3 {
+  color: var(--gray-600);
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+
+.stat-number {
+  display: block;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--gray-900);
+  line-height: 1;
+  margin-bottom: 0.25rem;
+}
+
+.stat-label {
+  color: var(--gray-500);
+  font-size: 0.75rem;
+}
+
+/* Charts */
+.charts-section {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.chart-card {
+  background: var(--bg-primary);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--gray-200);
+  /* Standardized chart card padding */
+  padding: var(--padding-md);
+}
+
+.chart-container {
+  margin-top: 1rem;
+  height: 300px;
+}
+
+/* Top Section */
+.top-section {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.top-card {
+  background: var(--bg-primary);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--gray-200);
+  /* Standardized top card padding */
+  padding: var(--padding-md);
+}
+
+.top-list {
+  max-height: 320px;
+  overflow-y: auto;
+  margin-top: 1rem;
+}
+
+.top-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  /* Standardized top item padding */
+  padding: var(--padding-xs) 0;
+  border-bottom: 1px solid var(--gray-200);
+}
+
+.top-item:last-child {
+  border-bottom: none;
+}
+
+.top-item-info {
+  flex: 1;
+  /* Center align top item info */
+  text-align: center;
+}
+
+.top-item-label {
+  font-weight: 500;
+  color: var(--gray-900);
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+}
+
+.top-item-detail {
+  font-size: 0.75rem;
+  color: var(--gray-500);
+  margin-top: 0.25rem;
+}
+
+.top-item-count {
+  background: var(--primary-color);
+  color: white;
+  padding: 0.25rem 0.75rem;
+  border-radius: var(--radius);
+  font-weight: 600;
+  font-size: 0.75rem;
+}
+
+/* Logs Section */
+.logs-section {
+  margin-bottom: 2rem;
+}
+
+.logs-section .card {
+  /* Standardized logs section padding */
+  padding: var(--padding-md);
+}
+
+.logs-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  /* Standardized logs header margin */
+  margin-bottom: var(--padding-md);
+  gap: 1rem;
+}
+
+.logs-controls {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  /* Center align logs controls */
+  justify-content: center;
+}
+
+.filter-select,
+.filter-input {
+  /* Standardized filter padding */
+  padding: var(--padding-xs);
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius);
+  font-size: 0.875rem;
+  background: var(--bg-primary);
+  color: var(--gray-900);
+  text-align: center;
+}
+
+.filter-select:focus,
+.filter-input:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgb(37 99 235 / 0.1);
+}
+
+.table-container {
+  overflow-x: auto;
+  /* Standardized table container margin */
+  margin-bottom: var(--padding-md);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--gray-200);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--bg-primary);
+}
+
+th {
+  background: var(--gray-50);
+  color: var(--gray-700);
+  /* Standardized table header padding and centered text */
+  padding: var(--padding-xs) var(--padding-sm);
+  text-align: center;
+  font-weight: 600;
+  font-size: 0.875rem;
+  border-bottom: 1px solid var(--gray-200);
+}
+
+td {
+  /* Standardized table cell padding and centered text */
+  padding: var(--padding-xs) var(--padding-sm);
+  border-bottom: 1px solid var(--gray-200);
+  font-size: 0.875rem;
+  vertical-align: middle;
+  text-align: center;
+}
+
+tr:hover {
+  background: var(--gray-50);
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+.protocol-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+.protocol-ssh {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.protocol-telnet {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+code {
+  font-family: var(--font-mono);
+  background: var(--gray-100);
+  padding: 0.125rem 0.25rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+}
+
+.page-info {
+  color: var(--gray-600);
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+/* Footer */
+.footer {
+  background: var(--bg-primary);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--gray-200);
+  /* Standardized footer padding */
+  padding: var(--padding-md);
+  text-align: center;
+}
+
+.footer-content p {
+  color: var(--gray-600);
+  font-size: 0.875rem;
+}
+
+.footer-content p:first-child {
+  font-weight: 600;
+  color: var(--gray-900);
+  margin-bottom: 0.25rem;
+}
+
+/* Toast Notifications */
+#toast-container {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1000;
+  max-width: 400px;
+}
+
+.toast {
+  background: var(--bg-primary);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  border: 1px solid var(--gray-200);
+  /* Standardized toast padding */
+  padding: var(--padding-sm) var(--padding-md);
+  margin-bottom: 0.75rem;
+  animation: slideIn 0.3s ease;
+  border-left: 4px solid;
+  /* Center align toast text */
+  text-align: center;
+}
+
+.toast.success {
+  border-left-color: var(--success-color);
+}
+
+.toast.error {
+  border-left-color: var(--danger-color);
+}
+
+.toast.info {
+  border-left-color: var(--info-color);
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
   }
-  
-  .stat-card {
-    background: var(--bg-primary);
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow);
-    border: 1px solid var(--gray-200);
-    padding: 1.5rem;
-    display: flex;
-    align-items: flex-start;
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+/* Loading */
+.loading {
+  text-align: center;
+  color: var(--gray-500);
+  font-style: italic;
+  /* Standardized loading padding */
+  padding: var(--padding-lg);
+}
+
+/* Modal Styles */
+.modal {
+  display: none;
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.modal-content {
+  background-color: var(--bg-primary);
+  margin: 5% auto;
+  padding: 0;
+  border-radius: var(--radius-xl);
+  width: 90%;
+  max-width: 800px;
+  box-shadow: var(--shadow-lg);
+}
+
+.modal-header {
+  padding: var(--padding-md);
+  border-bottom: 1px solid var(--gray-200);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  text-align: center;
+}
+
+.modal-body {
+  padding: var(--padding-md);
+  text-align: center;
+}
+
+.modal-close {
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--gray-500);
+}
+
+.modal-close:hover {
+  color: var(--gray-900);
+}
+
+/* Filter and Pagination Styles */
+.notifications-filters,
+.notifications-pagination {
+  margin-bottom: var(--padding-md);
+  text-align: center;
+}
+
+.filter-group {
+  display: inline-block;
+  margin: 0 var(--padding-xs);
+  text-align: center;
+}
+
+.filter-actions,
+.pagination-controls {
+  text-align: center;
+  margin-top: var(--padding-sm);
+}
+
+.pagination-info {
+  text-align: center;
+  margin-bottom: var(--padding-sm);
+}
+
+.session-info,
+.commands-list {
+  text-align: center;
+  margin-bottom: var(--padding-md);
+}
+
+.progress-bar {
+  background: var(--gray-200);
+  border-radius: var(--radius);
+  height: 0.5rem;
+  margin-top: var(--padding-sm);
+}
+
+.progress-fill {
+  background: var(--primary-color);
+  height: 100%;
+  border-radius: var(--radius);
+  transition: width 0.3s ease;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .container {
+    /* Responsive container padding */
+    padding: var(--padding-sm);
+  }
+
+  .header-content {
+    flex-direction: column;
     gap: 1rem;
-    transition: all 0.2s ease;
+    text-align: center;
   }
-  
-  .stat-card:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-lg);
-  }
-  
-  .stat-icon {
-    background: linear-gradient(135deg, var(--primary-color), var(--primary-light));
-    color: white;
-    padding: 0.75rem;
-    border-radius: var(--radius-lg);
-    display: flex;
-    align-items: center;
+
+  .control-buttons {
     justify-content: center;
   }
-  
-  .stat-content {
-    flex: 1;
-  }
-  
-  .stat-content h3 {
-    color: var(--gray-600);
-    font-size: 0.875rem;
-    font-weight: 500;
-    margin-bottom: 0.5rem;
-  }
-  
-  .stat-number {
-    display: block;
-    font-size: 2rem;
-    font-weight: 700;
-    color: var(--gray-900);
-    line-height: 1;
-    margin-bottom: 0.25rem;
-  }
-  
-  .stat-label {
-    color: var(--gray-500);
-    font-size: 0.75rem;
-  }
-  
-  /* Charts */
-  .charts-section {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 2rem;
-  }
-  
-  .chart-card {
-    background: var(--bg-primary);
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow);
-    border: 1px solid var(--gray-200);
-    padding: 1.5rem;
-  }
-  
-  .chart-container {
-    margin-top: 1rem;
-    height: 300px;
-  }
-  
-  /* Top Section */
-  .top-section {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 2rem;
-  }
-  
-  .top-card {
-    background: var(--bg-primary);
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow);
-    border: 1px solid var(--gray-200);
-    padding: 1.5rem;
-  }
-  
-  .top-list {
-    max-height: 320px;
-    overflow-y: auto;
-    margin-top: 1rem;
-  }
-  
-  .top-item {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.75rem 0;
-    border-bottom: 1px solid var(--gray-200);
-  }
-  
-  .top-item:last-child {
-    border-bottom: none;
-  }
-  
-  .top-item-info {
-    flex: 1;
-  }
-  
-  .top-item-label {
-    font-weight: 500;
-    color: var(--gray-900);
-    font-family: var(--font-mono);
-    font-size: 0.875rem;
-  }
-  
-  .top-item-detail {
-    font-size: 0.75rem;
-    color: var(--gray-500);
-    margin-top: 0.25rem;
-  }
-  
-  .top-item-count {
-    background: var(--primary-color);
-    color: white;
-    padding: 0.25rem 0.75rem;
-    border-radius: var(--radius);
-    font-weight: 600;
-    font-size: 0.75rem;
-  }
-  
-  /* Logs Section */
-  .logs-section {
-    margin-bottom: 2rem;
-  }
-  
-  .logs-section .card {
-    padding: 1.5rem;
-  }
-  
+
   .logs-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    margin-bottom: 1.5rem;
-    gap: 1rem;
+    flex-direction: column;
+    align-items: stretch;
   }
-  
+
   .logs-controls {
-    display: flex;
-    gap: 0.75rem;
-    flex-wrap: wrap;
+    justify-content: center;
   }
-  
-  .filter-select,
-  .filter-input {
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--gray-300);
-    border-radius: var(--radius);
-    font-size: 0.875rem;
-    background: var(--bg-primary);
-    color: var(--gray-900);
+
+  .charts-section {
+    grid-template-columns: 1fr;
   }
-  
-  .filter-select:focus,
-  .filter-input:focus {
-    outline: none;
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgb(37 99 235 / 0.1);
+
+  .stats-grid {
+    grid-template-columns: 1fr;
   }
-  
-  .table-container {
-    overflow-x: auto;
-    margin-bottom: 1.5rem;
-    border-radius: var(--radius-lg);
-    border: 1px solid var(--gray-200);
+
+  .top-section {
+    grid-template-columns: 1fr;
   }
-  
+
   table {
-    width: 100%;
-    border-collapse: collapse;
-    background: var(--bg-primary);
-  }
-  
-  th {
-    background: var(--gray-50);
-    color: var(--gray-700);
-    padding: 0.75rem 1rem;
-    text-align: left;
-    font-weight: 600;
-    font-size: 0.875rem;
-    border-bottom: 1px solid var(--gray-200);
-  }
-  
-  td {
-    padding: 0.75rem 1rem;
-    border-bottom: 1px solid var(--gray-200);
-    font-size: 0.875rem;
-    vertical-align: top;
-  }
-  
-  tr:hover {
-    background: var(--gray-50);
-  }
-  
-  tr:last-child td {
-    border-bottom: none;
-  }
-  
-  .protocol-badge {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.25rem 0.5rem;
-    border-radius: var(--radius-sm);
     font-size: 0.75rem;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.025em;
   }
-  
-  .protocol-ssh {
-    background: #dbeafe;
-    color: #1d4ed8;
+
+  th,
+  td {
+    /* Responsive table padding */
+    padding: var(--padding-xs);
   }
-  
-  .protocol-telnet {
-    background: #fef3c7;
-    color: #92400e;
+
+  .stat-card {
+    flex-direction: column;
+    text-align: center;
   }
-  
-  code {
-    font-family: var(--font-mono);
-    background: var(--gray-100);
-    padding: 0.125rem 0.25rem;
-    border-radius: var(--radius-sm);
+
+  .stat-icon {
+    align-self: center;
+  }
+
+  .reports-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .filter-group {
+    display: block;
+    margin-bottom: var(--padding-sm);
+  }
+}
+
+@media (max-width: 480px) {
+  .header-text h1 {
+    font-size: 1.5rem;
+  }
+
+  .stat-number {
+    font-size: 1.75rem;
+  }
+
+  .btn {
+    /* Responsive button padding */
+    padding: var(--padding-xs) var(--padding-sm);
     font-size: 0.8125rem;
   }
-  
-  .pagination {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 1rem;
-  }
-  
-  .page-info {
-    color: var(--gray-600);
-    font-size: 0.875rem;
-    font-weight: 500;
-  }
-  
-  /* Footer */
-  .footer {
-    background: var(--bg-primary);
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow);
-    border: 1px solid var(--gray-200);
-    padding: 1.5rem;
-    text-align: center;
-  }
-  
-  .footer-content p {
-    color: var(--gray-600);
-    font-size: 0.875rem;
-  }
-  
-  .footer-content p:first-child {
-    font-weight: 600;
-    color: var(--gray-900);
-    margin-bottom: 0.25rem;
-  }
-  
-  /* Toast Notifications */
+
   #toast-container {
-    position: fixed;
-    top: 1rem;
+    left: 1rem;
     right: 1rem;
-    z-index: 1000;
-    max-width: 400px;
+    max-width: none;
   }
-  
-  .toast {
-    background: var(--bg-primary);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-lg);
-    border: 1px solid var(--gray-200);
-    padding: 1rem 1.25rem;
-    margin-bottom: 0.75rem;
-    animation: slideIn 0.3s ease;
-    border-left: 4px solid;
+
+  .modal-content {
+    width: 95%;
+    margin: 2% auto;
   }
-  
-  .toast.success {
-    border-left-color: var(--success-color);
-  }
-  
-  .toast.error {
-    border-left-color: var(--danger-color);
-  }
-  
-  .toast.info {
-    border-left-color: var(--info-color);
-  }
-  
-  @keyframes slideIn {
-    from {
-      transform: translateX(100%);
-      opacity: 0;
-    }
-    to {
-      transform: translateX(0);
-      opacity: 1;
-    }
-  }
-  
-  /* Loading */
-  .loading {
-    text-align: center;
-    color: var(--gray-500);
-    font-style: italic;
-    padding: 2rem;
-  }
-  
-  /* Responsive Design */
-  @media (max-width: 768px) {
-    .container {
-      padding: 1rem;
-    }
-  
-    .header-content {
-      flex-direction: column;
-      gap: 1rem;
-      text-align: center;
-    }
-  
-    .control-buttons {
-      justify-content: center;
-    }
-  
-    .logs-header {
-      flex-direction: column;
-      align-items: stretch;
-    }
-  
-    .logs-controls {
-      justify-content: center;
-    }
-  
-    .charts-section {
-      grid-template-columns: 1fr;
-    }
-  
-    .stats-grid {
-      grid-template-columns: 1fr;
-    }
-  
-    .top-section {
-      grid-template-columns: 1fr;
-    }
-  
-    table {
-      font-size: 0.75rem;
-    }
-  
-    th,
-    td {
-      padding: 0.5rem;
-    }
-  
-    .stat-card {
-      flex-direction: column;
-      text-align: center;
-    }
-  
-    .stat-icon {
-      align-self: center;
-    }
-  }
-  
-  @media (max-width: 480px) {
-    .header-text h1 {
-      font-size: 1.5rem;
-    }
-  
-    .stat-number {
-      font-size: 1.75rem;
-    }
-  
-    .btn {
-      padding: 0.625rem 1.25rem;
-      font-size: 0.8125rem;
-    }
-  
-    #toast-container {
-      left: 1rem;
-      right: 1rem;
-      max-width: none;
-    }
-  }
-  
+}


### PR DESCRIPTION
Este *pull request* introduz um recurso abrangente de relatórios na aplicação, permitindo que os usuários gerem diversos relatórios (PDF e Excel) sobre ataques, estatísticas, notificações e dados consolidados. As mudanças abrangem o backend (Java Spring), a lógica do frontend em JavaScript e o CSS para novos elementos e estados da interface. Os principais pontos estão resumidos abaixo:

---

**Backend: Endpoints de Relatórios e Dependências**

* Adicionadas novas dependências no `pom.xml` para geração de relatórios em PDF (`itext7-core`) e Excel (`poi`, `poi-ooxml`, `poi-ooxml-schemas`).
* Criada a classe `ReportController` com endpoints REST para gerar e baixar relatórios de ataques, estatísticas, notificações e consolidados em formatos PDF e Excel. Também inclui um endpoint para acionar todos os relatórios de uma só vez.

---

**Frontend: Lógica de Geração de Relatórios**

* No `dashboard.js`, adicionados métodos para acionar a geração de relatórios via novos endpoints da API, gerenciar downloads de arquivos, atualizar estados da UI (gerando/sucesso/erro) e exibir *feedback*/notificações.
* Suporte para geração individual ou de todos os relatórios de uma vez, com progresso e atualização de status.

---

**UI/UX: Estilização do Painel de Relatórios**

* Adicionada nova seção em `dashboard-integration.css` para o painel de relatórios, incluindo layout em grid, cartões por categoria de relatório, design responsivo e feedback visual para os estados de geração (gerando, sucesso, erro).

---